### PR TITLE
implement hnreader-mode

### DIFF
--- a/hnreader.el
+++ b/hnreader.el
@@ -97,6 +97,9 @@ third one is 80.")
 (defvar hnreader--more-link nil
   "Load more link.")
 
+(define-derived-mode hnreader-mode org-mode "hnreader-mode"
+  "Minor mode associated to hnreader buffers.")
+
 ;;;###autoload
 (defun hnreader-back ()
   "Go back to previous location in history."
@@ -242,7 +245,7 @@ third one is 80.")
         (insert "\n* "))
       (insert (hnreader--get-morelink dom) " | ")
       (insert (format "[[elisp:(hnreader-read-page-back \"%s\")][Reload]]" url) )
-      (org-mode)
+      (hnreader-mode)
       (goto-char (point-min))
       (forward-line 2))))
 
@@ -329,7 +332,7 @@ third one is 80.")
         (insert "\n* " (format "[[elisp:(hnreader-comment \"%s\")][More]]" (concat "https://news.ycombinator.com/"
                                                                                    (dom-attr more-link 'href)))))
       (insert "\n* " (format  "[[elisp:(hnreader-comment \"%s\")][Reload]]" url))
-      (org-mode)
+      (hnreader-mode)
       ;; (org-shifttab 3)
       (goto-char (point-min))
       (forward-line 2))))


### PR DESCRIPTION
Use a dedicated mode, instead of using org. This way, one may declare hooks, mode variables, etc. in order to customize behavior.